### PR TITLE
Enhance DOM utilities: support HTMLElement inputs, detailed feedback, and safer handling

### DIFF
--- a/.changeset/all-schools-train.md
+++ b/.changeset/all-schools-train.md
@@ -1,0 +1,5 @@
+---
+"@bnidev/js-utils": minor
+---
+
+feat(dom): Accept both CSS selector strings and HTMLElements as input (all utilities)

--- a/.changeset/cold-regions-crash.md
+++ b/.changeset/cold-regions-crash.md
@@ -1,0 +1,5 @@
+---
+"@bnidev/js-utils": minor
+---
+
+feat(dom): Add `onScrollComplete` callback and error handling in `scrollToElementAfterRender`

--- a/.changeset/mean-states-sneeze.md
+++ b/.changeset/mean-states-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@bnidev/js-utils": patch
+---
+
+fix(dom): Safely handle null parent nodes in `toggleInertAround` to prevent errors

--- a/.changeset/moody-peaches-judge.md
+++ b/.changeset/moody-peaches-judge.md
@@ -1,0 +1,5 @@
+---
+"@bnidev/js-utils": minor
+---
+
+feat(dom): Add error handling and return error in `focusElement` if `focus()` throws

--- a/.changeset/pretty-moons-cough.md
+++ b/.changeset/pretty-moons-cough.md
@@ -1,0 +1,5 @@
+---
+"@bnidev/js-utils": minor
+---
+
+feat(dom): Return `null` or empty array when elements are not found (getElementDimensions`, `getFocusableElements`, `isElementInViewport`)

--- a/.changeset/quick-ads-attack.md
+++ b/.changeset/quick-ads-attack.md
@@ -1,0 +1,5 @@
+---
+"@bnidev/js-utils": minor
+---
+
+feat(dom): Return an object in `focusElement` to provide useful feedback and enable follow-up handling

--- a/src/dom/__tests__/focusElement.test.ts
+++ b/src/dom/__tests__/focusElement.test.ts
@@ -12,11 +12,23 @@ describe('focusElement', () => {
 
   afterEach(() => {
     element.remove()
+    vi.restoreAllMocks()
   })
 
   it('focuses the element and removes tabindex by default', () => {
     const focusSpy = vi.spyOn(element, 'focus')
-    focusElement('test-element')
+    const {
+      element: el,
+      attempted,
+      focused,
+      error
+    } = focusElement('#test-element')
+
+    expect(el).toBe(element)
+    expect(attempted).toBe(true)
+    expect(focused).toBe(true)
+    expect(error).toBeUndefined()
+
     expect(document.activeElement).toBe(element)
     expect(element.tabIndex).toBe(-1)
     expect(focusSpy).toHaveBeenCalled()
@@ -25,7 +37,18 @@ describe('focusElement', () => {
 
   it('focuses the element and keeps tabindex if removeTabIndex is false', () => {
     const focusSpy = vi.spyOn(element, 'focus')
-    focusElement('test-element', false)
+    const {
+      element: el,
+      attempted,
+      focused,
+      error
+    } = focusElement('#test-element', false)
+
+    expect(el).toBe(element)
+    expect(attempted).toBe(true)
+    expect(focused).toBe(true)
+    expect(error).toBeUndefined()
+
     expect(document.activeElement).toBe(element)
     expect(element.tabIndex).toBe(-1)
     expect(focusSpy).toHaveBeenCalled()
@@ -33,6 +56,68 @@ describe('focusElement', () => {
   })
 
   it('does nothing if the element does not exist', () => {
-    expect(() => focusElement('non-existent')).not.toThrow()
+    const {
+      element: el,
+      attempted,
+      focused,
+      error
+    } = focusElement('#non-existent')
+
+    expect(el).toBeNull()
+    expect(attempted).toBe(false)
+    expect(focused).toBe(false)
+    expect(error).toBeUndefined()
+  })
+
+  it('returns error if focus throws', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {}) // silence warning
+
+    vi.spyOn(element, 'focus').mockImplementation(() => {
+      throw new Error('Focus failed')
+    })
+
+    const { error } = focusElement('#test-element')
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toBe('Focus failed')
+
+    warnSpy.mockRestore() // restore console.warn after test
+  })
+
+  it('removes tabindex attribute by default', () => {
+    // Make sure element has tabindex set initially so removeAttribute matters
+    element.setAttribute('tabindex', '0')
+
+    const { element: el } = focusElement('#test-element')
+
+    expect(el).toBe(element)
+    expect(el?.hasAttribute('tabindex')).toBe(false)
+  })
+
+  it('removes tabindex attribute if removeTabIndex is true explicitly', () => {
+    element.setAttribute('tabindex', '3')
+    const { element: el } = focusElement('#test-element', true)
+
+    expect(el).toBe(element)
+    expect(el?.hasAttribute('tabindex')).toBe(false)
+  })
+
+  it('does not remove tabindex attribute if removeTabIndex is false', () => {
+    element.setAttribute('tabindex', '-1')
+    const { element: el } = focusElement('#test-element', false)
+    expect(el?.getAttribute('tabindex')).toBe('-1')
+  })
+
+  it('focuses the element when passed as an HTMLElement', () => {
+    const focusSpy = vi.spyOn(element, 'focus')
+    const { element: el, attempted, focused, error } = focusElement(element)
+
+    expect(el).toBe(element)
+    expect(attempted).toBe(true)
+    expect(focused).toBe(true)
+    expect(error).toBeUndefined()
+
+    expect(document.activeElement).toBe(element)
+    expect(focusSpy).toHaveBeenCalled()
   })
 })

--- a/src/dom/__tests__/getElementDimensions.test.ts
+++ b/src/dom/__tests__/getElementDimensions.test.ts
@@ -1,11 +1,22 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getElementDimensions } from '../getElementDimensions'
 
 describe('getElementDimensions', () => {
-  it('returns correct dimensions and position from getBoundingClientRect', () => {
-    const mockElement = document.createElement('div')
+  let element: HTMLElement
 
-    vi.spyOn(mockElement, 'getBoundingClientRect').mockReturnValue({
+  beforeEach(() => {
+    element = document.createElement('div')
+    element.id = 'test-element'
+    document.body.appendChild(element)
+  })
+
+  afterEach(() => {
+    element.remove()
+    vi.restoreAllMocks()
+  })
+
+  it('returns correct dimensions from a DOM element', () => {
+    const mockRect = {
       width: 100,
       height: 50,
       top: 10,
@@ -15,9 +26,12 @@ describe('getElementDimensions', () => {
       x: 20,
       y: 10,
       toJSON: () => {}
-    })
+    }
 
-    const result = getElementDimensions(mockElement)
+    vi.spyOn(element, 'getBoundingClientRect').mockReturnValue(mockRect)
+
+    const result = getElementDimensions(element)
+
     expect(result).toEqual({
       width: 100,
       height: 50,
@@ -26,5 +40,37 @@ describe('getElementDimensions', () => {
       right: 120,
       bottom: 60
     })
+  })
+
+  it('returns correct dimensions from a selector', () => {
+    const mockRect = {
+      width: 200,
+      height: 150,
+      top: 30,
+      left: 40,
+      right: 240,
+      bottom: 180,
+      x: 40,
+      y: 30,
+      toJSON: () => {}
+    }
+
+    vi.spyOn(element, 'getBoundingClientRect').mockReturnValue(mockRect)
+
+    const result = getElementDimensions('#test-element')
+
+    expect(result).toEqual({
+      width: 200,
+      height: 150,
+      top: 30,
+      left: 40,
+      right: 240,
+      bottom: 180
+    })
+  })
+
+  it('returns null if selector does not match any element', () => {
+    const result = getElementDimensions('#non-existent')
+    expect(result).toBeNull()
   })
 })

--- a/src/dom/__tests__/getFocusableElements.test.ts
+++ b/src/dom/__tests__/getFocusableElements.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { getFocusableElements } from '../getFocusableElements'
 
 describe('getFocusableElements', () => {
-  it('returns only focusable elements', () => {
-    // Create a mock container with various elements
-    const container = document.createElement('div')
+  let container: HTMLElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    container.id = 'test-container'
     container.innerHTML = `
       <a href="#">Link</a>
       <button>Button</button>
@@ -19,12 +21,16 @@ describe('getFocusableElements', () => {
       <div style="display: none" tabindex="0">Hidden via display</div>
       <div style="visibility: hidden" tabindex="0">Hidden via visibility</div>
     `
-
     document.body.appendChild(container)
+  })
 
+  afterEach(() => {
+    container.remove()
+  })
+
+  it('returns only visible, enabled focusable elements from an HTMLElement', () => {
     const result = getFocusableElements(container)
 
-    // Should return the valid, visible focusable elements
     expect(result).toHaveLength(6)
     expect(result.map((el) => el.tagName.toLowerCase())).toEqual([
       'a',
@@ -34,18 +40,36 @@ describe('getFocusableElements', () => {
       'textarea',
       'div'
     ])
-
-    document.body.removeChild(container)
   })
 
-  it('returns an empty array if no focusable elements exist', () => {
-    const container = document.createElement('div')
-    container.innerHTML = `
-      <div>Plain text</div>
-      <span>Span</span>
-    `
+  it('returns only visible, enabled focusable elements from a selector', () => {
+    const result = getFocusableElements('#test-container')
 
-    const result = getFocusableElements(container)
+    expect(result).toHaveLength(6)
+    expect(result.map((el) => el.tagName.toLowerCase())).toEqual([
+      'a',
+      'button',
+      'input',
+      'select',
+      'textarea',
+      'div'
+    ])
+  })
+
+  it('returns an empty array when container selector does not match', () => {
+    const result = getFocusableElements('#non-existent')
     expect(result).toEqual([])
+  })
+
+  it('returns an empty array if container has no focusable elements', () => {
+    const emptyContainer = document.createElement('div')
+    emptyContainer.id = 'empty'
+    emptyContainer.innerHTML = `<p>Text only</p><span>No tabindex</span>`
+    document.body.appendChild(emptyContainer)
+
+    const result = getFocusableElements('#empty')
+    expect(result).toEqual([])
+
+    emptyContainer.remove()
   })
 })

--- a/src/dom/__tests__/isElementInViewport.test.ts
+++ b/src/dom/__tests__/isElementInViewport.test.ts
@@ -104,4 +104,30 @@ describe('isElementInViewport', () => {
   it('returns false if the element is null', () => {
     expect(isElementInViewport(null as unknown as HTMLElement)).toBe(false)
   })
+
+  it('returns true when given a selector of a visible element', () => {
+    const el = document.createElement('div')
+    el.id = 'visible-element'
+    document.body.appendChild(el)
+
+    vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+      top: 50,
+      left: 50,
+      bottom: 150,
+      right: 150,
+      width: 100,
+      height: 100,
+      x: 50,
+      y: 50,
+      toJSON: () => {}
+    })
+
+    expect(isElementInViewport('#visible-element')).toBe(true)
+
+    document.body.removeChild(el)
+  })
+
+  it('returns false when given a selector that matches no element', () => {
+    expect(isElementInViewport('#non-existent')).toBe(false)
+  })
 })

--- a/src/dom/__tests__/scrollToElementAfterRender.test.ts
+++ b/src/dom/__tests__/scrollToElementAfterRender.test.ts
@@ -24,24 +24,83 @@ describe('scrollToElementAfterRender', () => {
     vi.restoreAllMocks()
   })
 
-  it('calls scrollIntoView with smooth behavior by default', () => {
-    scrollToElementAfterRender('test-element')
+  it('scrolls via selector with smooth behavior by default', () => {
+    scrollToElementAfterRender('#test-element')
 
     expect(element.scrollIntoView).toHaveBeenCalledWith({
       behavior: 'smooth'
     })
   })
 
-  it('calls scrollIntoView with auto behavior when smooth is false', () => {
-    scrollToElementAfterRender('test-element', false)
+  it('scrolls via selector with auto behavior when smooth is false', () => {
+    scrollToElementAfterRender('#test-element', false)
 
     expect(element.scrollIntoView).toHaveBeenCalledWith({
       behavior: 'auto'
     })
   })
 
-  it('does nothing if the element is not found', () => {
-    // Should not throw
-    expect(() => scrollToElementAfterRender('non-existent')).not.toThrow()
+  it('scrolls via HTMLElement reference with smooth behavior by default', () => {
+    scrollToElementAfterRender(element)
+
+    expect(element.scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'smooth'
+    })
+  })
+
+  it('scrolls via HTMLElement reference with auto behavior', () => {
+    scrollToElementAfterRender(element, false)
+
+    expect(element.scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'auto'
+    })
+  })
+
+  it('does nothing if element is not found via selector', () => {
+    expect(() => scrollToElementAfterRender('#non-existent')).not.toThrow()
+  })
+
+  it('does nothing if null is passed', () => {
+    expect(() =>
+      scrollToElementAfterRender(null as unknown as string)
+    ).not.toThrow()
+  })
+
+  it('calls onScrollComplete callback with success info', () => {
+    return new Promise<void>((resolve, reject) => {
+      scrollToElementAfterRender(
+        '#test-element',
+        true,
+        ({ element: el, error, durationMs }) => {
+          try {
+            expect(el).toBe(element)
+            expect(error).toBeUndefined()
+            expect(typeof durationMs).toBe('number')
+            resolve()
+          } catch (err) {
+            reject(err)
+          }
+        }
+      )
+    })
+  })
+
+  it('calls onScrollComplete callback with error info when scrollIntoView throws', () => {
+    // Mock scrollIntoView to throw error
+    element.scrollIntoView = vi.fn(() => {
+      throw new Error('scroll error')
+    })
+
+    return new Promise<void>((resolve, reject) => {
+      scrollToElementAfterRender('#test-element', true, ({ error }) => {
+        try {
+          expect(error).toBeInstanceOf(Error)
+          expect((error as Error).message).toBe('scroll error')
+          resolve()
+        } catch (err) {
+          reject(err)
+        }
+      })
+    })
   })
 })

--- a/src/dom/__tests__/toggleInertAround.test.ts
+++ b/src/dom/__tests__/toggleInertAround.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { toggleInertAround } from '../toggleInertAround'
 
 describe('toggleInertAround', () => {
@@ -26,7 +26,7 @@ describe('toggleInertAround', () => {
     container.remove()
   })
 
-  it('toggles inert attribute on siblings of the target and its ancestors', () => {
+  it('toggles inert attribute on siblings of the target and its ancestors (by id)', () => {
     const sibling2a = document.getElementById('sibling2a')
     const level2b = document.getElementById('level2b')
     const level1b = document.getElementById('level1b')
@@ -52,8 +52,49 @@ describe('toggleInertAround', () => {
     expect(level1b.hasAttribute('inert')).toBe(false)
   })
 
+  it('toggles inert attribute on siblings of the target and its ancestors (by element)', () => {
+    const targetEl = document.getElementById('target')
+    const sibling2a = document.getElementById('sibling2a')
+    const level2b = document.getElementById('level2b')
+    const level1b = document.getElementById('level1b')
+    if (!targetEl || !sibling2a || !level2b || !level1b)
+      throw new Error('Test setup failed')
+
+    // Initial: no inert attributes
+    expect(sibling2a.hasAttribute('inert')).toBe(false)
+    expect(level2b.hasAttribute('inert')).toBe(false)
+    expect(level1b.hasAttribute('inert')).toBe(false)
+
+    toggleInertAround(targetEl)
+
+    // Siblings should now have inert
+    expect(sibling2a.hasAttribute('inert')).toBe(true)
+    expect(level2b.hasAttribute('inert')).toBe(true)
+    expect(level1b.hasAttribute('inert')).toBe(true)
+
+    // Toggle again to remove inert
+    toggleInertAround(targetEl)
+
+    expect(sibling2a.hasAttribute('inert')).toBe(false)
+    expect(level2b.hasAttribute('inert')).toBe(false)
+    expect(level1b.hasAttribute('inert')).toBe(false)
+  })
+
   it('does nothing if the target does not exist', () => {
-    // Should not throw
     expect(() => toggleInertAround('non-existent')).not.toThrow()
+  })
+
+  it('breaks the loop if parent is null', () => {
+    // Create an element with no parent
+    const orphan = document.createElement('div')
+    orphan.id = 'orphan'
+
+    // Spy on document.getElementById to return this orphan
+    vi.spyOn(document, 'getElementById').mockReturnValue(orphan)
+
+    // Should not throw, and cover the parent null branch
+    expect(() => toggleInertAround('orphan')).not.toThrow()
+
+    vi.restoreAllMocks()
   })
 })

--- a/src/dom/focusElement.ts
+++ b/src/dom/focusElement.ts
@@ -1,11 +1,19 @@
 /**
- * Focuses the HTML element with the specified ID.
+ * Focuses the specified HTML element or the first element matching a CSS selector.
  *
  * Sets the element's `tabIndex` to -1 to make it focusable if necessary,
- * focuses the element, and optionally removes the `tabindex` attribute after focusing.
+ * attempts to focus it, and optionally removes the `tabindex` attribute afterward.
  *
- * @param targetId - The ID of the element to focus.
+ * Returns a result object containing the element, whether focus was attempted,
+ * whether it was successful, and any error encountered.
+ *
+ * @param selectorOrElement - A CSS selector string or a DOM Element to focus.
  * @param removeTabIndex - Whether to remove the `tabindex` attribute after focusing. Defaults to true.
+ * @returns An object describing the focus attempt:
+ * - `element`: The resolved element or null.
+ * - `attempted`: Whether the function attempted to focus an element.
+ * - `focused`: Whether the element successfully received focus.
+ * - `error` (optional): Any error thrown during the focus attempt.
  *
  * @category DOM
  *
@@ -20,24 +28,68 @@
  *
  * @example Usage
  * ```ts
- * // Focus an element with ID 'myElement'
- * focusElement('myElement')
+ * // Just focus the element (no need to capture the return value)
+ * focusElement('#myElement');
  *
- * // Focus an element with ID 'myElement' without removing tabindex
- * focusElement('myElement', false)
+ * // Focus an element without removing tabindex
+ * focusElement('#myElement', false);
+ *
+ * // Focus a specific DOM element
+ * const myElement = document.getElementById('myElement');
+ * focusElement(myElement);
+ *
+ * // Use the returned result object (destructured)
+ * const { element, attempted, focused, error } = focusElement('#myElement');
+ *
+ * if (focused) {
+ *   console.log('Element focused successfully:', element);
+ * } else if (!element) {
+ *   console.warn('Element not found.');
+ * } else if (!attempted) {
+ *   console.warn('Focus was not attempted.');
+ * } else {
+ *   console.warn('Focus failed.', error);
+ * }
  * ```
  */
-
 export function focusElement(
-  targetId: string,
+  selectorOrElement: string | HTMLElement,
   removeTabIndex: boolean = true
-): void {
-  const targetElement = document.getElementById(targetId)
-  if (targetElement) {
-    targetElement.tabIndex = -1
-    targetElement.focus()
-    if (removeTabIndex) {
-      targetElement.removeAttribute('tabindex')
+): {
+  element: HTMLElement | null
+  attempted: boolean
+  focused: boolean
+  error?: unknown
+} {
+  let element: HTMLElement | null
+  let attempted = false
+  let focused = false
+  let error: unknown
+
+  if (typeof selectorOrElement === 'string') {
+    element = document.querySelector<HTMLElement>(selectorOrElement)
+  } else {
+    element = selectorOrElement
+  }
+  if (element) {
+    attempted = true
+    try {
+      element.tabIndex = -1
+      element.focus()
+      focused = document.activeElement === element
+      if (removeTabIndex) {
+        element.removeAttribute('tabindex')
+      }
+    } catch (err) {
+      error = err
+      console.warn('focusElement: Failed to focus element', err)
     }
+  }
+
+  return {
+    element,
+    attempted,
+    focused,
+    ...(error ? { error } : {})
   }
 }

--- a/src/dom/getElementDimensions.ts
+++ b/src/dom/getElementDimensions.ts
@@ -1,11 +1,9 @@
 /**
- * Gets the dimensions and position of a DOM element.
+ * Gets the dimensions and position of a DOM element or the first element matching a CSS selector.
  *
- * @param element - The DOM element to measure.
- * @returns An object containing the width, height, top, left, right, and bottom values of the element.
- *
- * @remarks
- * This utility is helpful when you need to calculate layout, positioning, or do measurements for animations or interactions.
+ * @param selectorOrElement - A CSS selector string or a DOM Element to measure.
+ * @returns An object containing the width, height, top, left, right, and bottom values of the element,
+ * or `null` if no element is found.
  *
  * @category DOM
  *
@@ -20,15 +18,39 @@
  *
  * @example Usage
  * ```ts
- * const el = document.getElementById('my-element')
- * if (el) {
- *   const dims = getElementDimensions(el)
+ * const dims = getElementDimensions('#my-element')
+ * if (dims) {
  *   console.log(dims.width, dims.height)
+ * }
+ *
+ * // Or with a DOM element
+ * const el = document.getElementById('my-element')
+ * const dims2 = getElementDimensions(el)
+ * if (dims2) {
+ *   console.log(dims2.top, dims2.left)
  * }
  * ```
  */
-export function getElementDimensions(element: Element) {
+export function getElementDimensions(selectorOrElement: string | Element): {
+  width: number
+  height: number
+  top: number
+  left: number
+  right: number
+  bottom: number
+} | null {
+  let element: Element | null
+
+  if (typeof selectorOrElement === 'string') {
+    element = document.querySelector<HTMLElement>(selectorOrElement)
+  } else {
+    element = selectorOrElement
+  }
+
+  if (!element) return null
+
   const rect = element.getBoundingClientRect()
+
   return {
     width: rect.width,
     height: rect.height,

--- a/src/dom/getFocusableElements.ts
+++ b/src/dom/getFocusableElements.ts
@@ -3,7 +3,7 @@
  * Focusable elements include links, buttons, textareas, inputs, selects,
  * and elements with a positive tabindex.
  *
- * @param {HTMLElement} container - The container element to search within.
+ * @param containerOrSelector - A CSS selector string or an HTMLElement representing the container.
  * @returns {HTMLElement[]} An array of focusable elements.
  *
  * @remarks
@@ -23,14 +23,29 @@
  *
  * @example Usage
  * ```ts
- * // Get all focusable elements within a modal dialog
+ * // With a selector
+ * const focusables = getFocusableElements('.modal')
+ *
+ * // With a direct HTMLElement
  * const modal = document.querySelector('.modal')
- * const focusableElements = getFocusableElements(modal)
- * // Log the focusable elements
- * console.log(focusableElements)
+ * if (modal) {
+ *   const focusables = getFocusableElements(modal)
+ * }
  * ```
  */
-export function getFocusableElements(container: HTMLElement): HTMLElement[] {
+export function getFocusableElements(
+  containerOrSelector: string | HTMLElement
+): HTMLElement[] {
+  let container: HTMLElement | null
+
+  if (typeof containerOrSelector === 'string') {
+    container = document.querySelector<HTMLElement>(containerOrSelector)
+  } else {
+    container = containerOrSelector
+  }
+
+  if (!container) return []
+
   const elements = container.querySelectorAll<HTMLElement>(
     'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])'
   )

--- a/src/dom/isElementInViewport.ts
+++ b/src/dom/isElementInViewport.ts
@@ -37,7 +37,7 @@ export function isElementInViewport(
 ): boolean {
   const element =
     typeof selectorOrElement === 'string'
-      ? document.querySelector(selectorOrElement)
+      ? document.querySelector<HTMLElement>(selectorOrElement)
       : selectorOrElement
 
   if (!element) return false

--- a/src/dom/isElementInViewport.ts
+++ b/src/dom/isElementInViewport.ts
@@ -1,7 +1,7 @@
 /**
  * Determines if a given element is currently visible in the viewport.
  *
- * @param el - The DOM element to check.
+ * @param selectorOrElement - A CSS selector string or an HTMLElement.
  * @returns `true` if the element is in the viewport, `false` otherwise.
  *
  * @remarks
@@ -20,18 +20,29 @@
  *
  * @example Usage
  * ```ts
- * const el = document.querySelector('#my-element')
- * if (isElementInViewport(el)) {
- *   console.log('Element is visible')
+ * // With a CSS selector
+ * if (isElementInViewport('#my-element')) {
+ *   console.log('Visible')
+ * }
+ *
+ * // With an element
+ * const el = document.getElementById('my-element')
+ * if (el && isElementInViewport(el)) {
+ *   console.log('Also visible')
  * }
  * ```
  */
-export function isElementInViewport(el: HTMLElement): boolean {
-  if (!el) {
-    return false
-  }
+export function isElementInViewport(
+  selectorOrElement: string | HTMLElement
+): boolean {
+  const element =
+    typeof selectorOrElement === 'string'
+      ? document.querySelector(selectorOrElement)
+      : selectorOrElement
 
-  const rect = el.getBoundingClientRect()
+  if (!element) return false
+
+  const rect = element.getBoundingClientRect()
 
   return (
     rect.top >= 0 &&

--- a/src/dom/scrollToElementAfterRender.ts
+++ b/src/dom/scrollToElementAfterRender.ts
@@ -1,10 +1,12 @@
 /**
- * Scrolls the element with the specified ID into view after the next render frame.
+ * Scrolls the element with the specified ID or element reference into view after the next render frame.
  *
  * Uses `requestAnimationFrame` to ensure the scroll occurs after rendering.
  *
- * @param id - The ID of the element to scroll into view.
+ * @param selectorOrElement - A CSS selector or an element to scroll into view.
  * @param smooth - Whether to use smooth scrolling. Defaults to true.
+ * @param onScrollComplete - Optional callback invoked after scroll attempt with info about the element,
+ *   any error, and how long the scroll attempt took (in milliseconds).
  *
  * @category DOM
  *
@@ -19,21 +21,62 @@
  *
  * @example Usage
  * ```ts
- * // Scroll to an element with ID 'myElement' smoothly after render
- * scrollToElementAfterRender('myElement')
+ * // Scroll to an element by CSS selector
+ * scrollToElementAfterRender('#myElement')
  *
- * // Scroll to an element with ID 'myElement' instantly after render
- * scrollToElementAfterRender('myElement', false)
+ * // Scroll to an element by CSS selector instantly (no smooth scrolling)
+ * scrollToElementAfterRender('#myElement', false)
+ *
+ * // Scroll to a DOM element reference
+ * const el = document.getElementById('myElement')
+ * if (el) {
+ *   scrollToElementAfterRender(el)
+ * }
+ *
+ * // Scroll with a completion callback
+ * scrollToElementAfterRender('#myElement', true, ({ element, error, durationMs }) => {
+ *   if (error) console.error('Scroll failed:', error)
+ *   else console.log('Scrolled element:', element, 'in', durationMs, 'ms')
+ * })
  * ```
  */
 
 export function scrollToElementAfterRender(
-  id: string,
-  smooth: boolean = true
+  selectorOrElement: string | HTMLElement,
+  smooth: boolean = true,
+  onScrollComplete?: (info: {
+    element: HTMLElement | null
+    error?: unknown
+    durationMs: number
+  }) => void
 ): void {
+  const start = performance.now()
+
   requestAnimationFrame(() => {
-    document
-      .getElementById(id)
-      ?.scrollIntoView({ behavior: smooth ? 'smooth' : 'auto' })
+    let element: HTMLElement | null = null
+    let error: unknown
+
+    try {
+      if (typeof selectorOrElement === 'string') {
+        element = document.querySelector<HTMLElement>(selectorOrElement)
+      } else {
+        element = selectorOrElement
+      }
+
+      if (element) {
+        element.scrollIntoView({ behavior: smooth ? 'smooth' : 'auto' })
+      }
+    } catch (err) {
+      error = err
+      console.warn('scrollToElementAfterRender: Failed to scroll element', err)
+    }
+
+    if (onScrollComplete) {
+      onScrollComplete({
+        element,
+        error,
+        durationMs: performance.now() - start
+      })
+    }
   })
 }

--- a/src/dom/scrollToElementAfterRender.ts
+++ b/src/dom/scrollToElementAfterRender.ts
@@ -1,5 +1,5 @@
 /**
- * Scrolls the element with the specified ID or element reference into view after the next render frame.
+ * Scrolls the element with the specified CSS selector or element reference into view after the next render frame.
  *
  * Uses `requestAnimationFrame` to ensure the scroll occurs after rendering.
  *

--- a/src/dom/toggleInertAround.ts
+++ b/src/dom/toggleInertAround.ts
@@ -4,7 +4,7 @@
  * For each ancestor of the target element (up to the document root), this function finds all sibling elements
  * and toggles their 'inert' attribute. If a sibling has the 'inert' attribute, it is removed; otherwise, it is added.
  *
- * @param targetId - The id of the target element around which to toggle 'inert' on siblings.
+ * @param target - The target element or the ID of the target element around which to toggle 'inert' on siblings.
  *
  * @category DOM
  *
@@ -19,31 +19,36 @@
  *
  * @example Usage
  * ```ts
+ * // Toggle 'inert' around an element by ID
  * toggleInertAround('myElementId')
+ *
+ * // Toggle 'inert' around a DOM element
+ * const el = document.getElementById('myElementId')
+ * if (el) {
+ *   toggleInertAround(el)
+ * }
  * ```
  */
 
-export function toggleInertAround(targetId: string): void {
-  let element: HTMLElement | null = document.getElementById(targetId)
+export function toggleInertAround(target: string | HTMLElement): void {
+  let element: HTMLElement | null =
+    typeof target === 'string' ? document.getElementById(target) : target
 
   while (element && element.parentNode !== document) {
-    const parent: HTMLElement = element.parentElement as HTMLElement
+    const parent = element.parentElement
+    if (!parent) break
 
-    if (parent) {
-      const siblings: HTMLElement[] = Array.from(parent.children).filter(
-        (sibling) => sibling !== element && sibling.nodeType === 1
-      ) as HTMLElement[]
+    const siblings = Array.from(parent.children).filter(
+      (sibling) => sibling !== element && sibling.nodeType === 1
+    ) as HTMLElement[]
 
-      if (siblings.length) {
-        siblings.forEach((sibling) => {
-          if (sibling.hasAttribute('inert')) {
-            sibling.removeAttribute('inert')
-          } else {
-            sibling.setAttribute('inert', '')
-          }
-        })
+    siblings.forEach((sibling) => {
+      if (sibling.hasAttribute('inert')) {
+        sibling.removeAttribute('inert')
+      } else {
+        sibling.setAttribute('inert', '')
       }
-    }
+    })
 
     element = parent
   }


### PR DESCRIPTION
## Changes
- Support both CSS selector strings and HTMLElements as inputs across all DOM utilities
- Return `null` or empty arrays when target elements are not found, avoiding errors
- Enhance `focusElement` to return a detailed result object with focus attempt status and error info
- Make `scrollToElementAfterRender` accept HTMLElements and handle errors with callback feedback
- Add safe handling for null parents in `toggleInertAround` to prevent runtime errors